### PR TITLE
fix: register mcp handlers for filtered commands only

### DIFF
--- a/src/commands/mcp/index.ts
+++ b/src/commands/mcp/index.ts
@@ -886,7 +886,7 @@ export default class Mcp extends Command {
   private async registerMcpHandlers(): Promise<void> {
     // Store all commands for tool discovery
     const allCommands: Command.Loadable[] = []
-    for (const cmdClass of this.config.commands as Command.Loadable[]) {
+    for (const cmdClass of this.filteredCommands) {
       if (cmdClass.hidden || cmdClass.disableMCP || cmdClass.id === 'mcp') continue
       allCommands.push(cmdClass)
     }


### PR DESCRIPTION
Only register MCP handlers for commands that exist in `this.filteredCommands`